### PR TITLE
fix: @ember/debug does not have a deprecate export

### DIFF
--- a/addon-test-support/only.js
+++ b/addon-test-support/only.js
@@ -1,4 +1,4 @@
-import { deprecate } from '@ember/debug';
+import { deprecate } from '@ember/application/deprecations';
 import { only as emberQUnitOnly } from 'ember-qunit';
 import { wrapTest, commonConfig } from './utils/config';
 

--- a/addon-test-support/test.js
+++ b/addon-test-support/test.js
@@ -1,4 +1,4 @@
-import { deprecate } from '@ember/debug';
+import { deprecate } from '@ember/application/deprecations';
 import { test as emberQUnitTest } from 'ember-qunit';
 import { wrapTest, commonConfig } from './utils/config';
 


### PR DESCRIPTION
Resolved using `import { deprecate } from '@ember/application/deprecations';`